### PR TITLE
Curate ecosystem references

### DIFF
--- a/about/ecosystem.md
+++ b/about/ecosystem.md
@@ -3,13 +3,13 @@
 ## General purpose
 
 - [Bambi](https://github.com/bambinos/bambi): BAyesian Model-Building Interface (BAMBI) in Python.
+- [calibr8](https://github.com/JuBiotech/calibr8): A toolbox for constructing detailed observation models to be used as likelihoods in PyMC.
+- [gumbi](https://github.com/JohnGoertz/Gumbi): A high-level interface for building GP models.
 - [SunODE](https://github.com/aseyboldt/sunode): Fast ODE solver, much faster than the one that comes with PyMC.
 - [pymc-learn](https://github.com/pymc-learn/pymc-learn): Custom PyMC models built on top of pymc3_models/scikit-learn API
-- [fenics-pymc3](https://github.com/IvanYashchuk/fenics-pymc3): Differentiable interface to FEniCS, a library for solving partial differential equations.
 
 ## Domain specific
 
 - [Exoplanet](https://github.com/dfm/exoplanet): a toolkit for modeling of transit and/or radial velocity observations of exoplanets and other astronomical time series.
-- [NiPyMC](https://github.com/PsychoinformaticsLab/nipymc): Bayesian mixed-effects modeling of fMRI data in Python.
 - [beat](https://github.com/hvasbath/beat): Bayesian Earthquake Analysis Tool.
-- [cell2location](https://github.com/BayraktarLab/cell2location): Comprehensive mapping of tissue cell architecture via integrated single cell and spatial transcriptomics.
+- [CasualPy](https://github.com/pymc-labs/CausalPy): A package focussing on causal inference in quasi-experimental settings.

--- a/about/ecosystem.md
+++ b/about/ecosystem.md
@@ -5,7 +5,7 @@
 - [Bambi](https://github.com/bambinos/bambi): BAyesian Model-Building Interface (BAMBI) in Python.
 - [calibr8](https://github.com/JuBiotech/calibr8): A toolbox for constructing detailed observation models to be used as likelihoods in PyMC.
 - [CausalPy](https://github.com/pymc-labs/CausalPy): A package focussing on causal inference in quasi-experimental settings.
-- [SunODE](https://github.com/aseyboldt/sunode): Fast ODE solver, much faster than the one that comes with PyMC.
+- [SunODE](https://github.com/pymc-devs/sunode): Fast ODE solver, much faster than the one that comes with PyMC.
 - [pymc-learn](https://github.com/pymc-learn/pymc-learn): Custom PyMC models built on top of pymc3_models/scikit-learn API
 
 ## Domain specific

--- a/about/ecosystem.md
+++ b/about/ecosystem.md
@@ -12,4 +12,4 @@
 
 - [Exoplanet](https://github.com/dfm/exoplanet): a toolkit for modeling of transit and/or radial velocity observations of exoplanets and other astronomical time series.
 - [beat](https://github.com/hvasbath/beat): Bayesian Earthquake Analysis Tool.
-- [CasualPy](https://github.com/pymc-labs/CausalPy): A package focussing on causal inference in quasi-experimental settings.
+- [CausalPy](https://github.com/pymc-labs/CausalPy): A package focussing on causal inference in quasi-experimental settings.

--- a/about/ecosystem.md
+++ b/about/ecosystem.md
@@ -4,7 +4,7 @@
 
 - [Bambi](https://github.com/bambinos/bambi): BAyesian Model-Building Interface (BAMBI) in Python.
 - [calibr8](https://github.com/JuBiotech/calibr8): A toolbox for constructing detailed observation models to be used as likelihoods in PyMC.
-- [gumbi](https://github.com/JohnGoertz/Gumbi): A high-level interface for building GP models.
+- [CausalPy](https://github.com/pymc-labs/CausalPy): A package focussing on causal inference in quasi-experimental settings.
 - [SunODE](https://github.com/aseyboldt/sunode): Fast ODE solver, much faster than the one that comes with PyMC.
 - [pymc-learn](https://github.com/pymc-learn/pymc-learn): Custom PyMC models built on top of pymc3_models/scikit-learn API
 
@@ -12,4 +12,3 @@
 
 - [Exoplanet](https://github.com/dfm/exoplanet): a toolkit for modeling of transit and/or radial velocity observations of exoplanets and other astronomical time series.
 - [beat](https://github.com/hvasbath/beat): Bayesian Earthquake Analysis Tool.
-- [CausalPy](https://github.com/pymc-labs/CausalPy): A package focussing on causal inference in quasi-experimental settings.


### PR DESCRIPTION
I removed references to packages that are no longer maintained, or no longer use PyMC.

Added links to actively maintained projects, some of which are maintained by core devs.