### PR TITLE
Use the pip magic to install `micropymc`

### DIFF
--- a/pymc_example.ipynb
+++ b/pymc_example.ipynb
@@ -8,9 +8,7 @@
    "outputs": [],
    "source": [
     "# This cell is only needed in this documentation page\n",
-    "# do not try to run this in your Notebooks if not using JupyterLite, it won't work :)\n",
-    "import piplite\n",
-    "await piplite.install(\"micropymc\")"
+    "%pip install micropymc"
    ]
   },
   {


### PR DESCRIPTION
With the latest releases of JupyterLite it is now possible to use the `%pip` magic to install packages in the Pyodide kernel:

![image](https://user-images.githubusercontent.com/591645/208936219-366e5b93-bea0-402d-9990-fa5809766eae.png)

This should make the interactive demo less confusing to users who are likely more familiar with `%pip`.