### PR TITLE
Use pip install pymc instead of micropymc in jupyter-lite example.

### DIFF
--- a/pymc_example.ipynb
+++ b/pymc_example.ipynb
@@ -7,8 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This cell is only needed in this documentation page\n",
-    "%pip install micropymc"
+    "%pip install pymc"
    ]
   },
   {


### PR DESCRIPTION
Turns out that pymc works natively now.