### PR TITLE
add sitemap and robots.txt

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "pymcio"
+          single-version: true

--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "notfound.extension",
     "jupyterlite_sphinx",
     "sphinxext.rediraffe",
+    "sphinx_sitemap",
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -134,6 +135,9 @@ jupyterlite_bind_ipynb_suffix = False
 # a list of builtin themes.
 #
 html_theme = "pymc_sphinx_theme"
+html_baseurl = "https://www.pymc.io/"
+sitemap_url_scheme = "{link}"
+html_extra_path = ["robots.txt", "sitemapindex.xml"]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jupyterlite-sphinx
 jupyterlite-pyodide-kernel
 sphinxext-rediraffe
 pymc-sphinx-theme==0.14
+sphinx-sitemap

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Sitemap: https://www.pymc.io/sitemapindex.xml

--- a/sitemapindex.xml
+++ b/sitemapindex.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+   <sitemap>
+      <loc>https://www.pymc.io/sitemap.xml</loc>
+   </sitemap>
+
+   <sitemap>
+     <loc>https://www.pymc.io/projects/docs/en/stable/sitemap.xml</loc>
+   </sitemap>
+
+   <sitemap>
+     <loc>https://www.pymc.io/projects/examples/en/latest/sitemap.xml</loc>
+   </sitemap>
+
+</sitemapindex>


### PR DESCRIPTION
Add sitemap and robots.txt. I have also added a sitemapindex file to signal that
all 3 "sub-websites" (landing+blog, docs and examples) should be treated as parts of a whole.


<!-- readthedocs-preview pymcio start -->
----
📚 Documentation preview 📚: https://pymcio--97.org.readthedocs.build/en/97/

<!-- readthedocs-preview pymcio end -->