### PR TITLE
Replace Twitter with X and add Mastodon to social media list

### DIFF
--- a/blog/PyMC_Past_Present_Future.md
+++ b/blog/PyMC_Past_Present_Future.md
@@ -166,5 +166,6 @@ Connect with PyMC via:
 - YouTube: [PyMCDevelopers](https://www.youtube.com/c/PyMCDevelopers)
 - Star GH repo:  [pymc-devs/pymc](https://github.com/pymc-devs/pymc)
 - Join Meetup: [pymc-online-meetup](https://www.meetup.com/pymc-online-meetup/)
-- Twitter: [@pymc_devs](https://twitter.com/pymc_devs)
+- X: [@pymc_devs](https://x.com/pymc_devs)
+- Mastodon: [@pymc](https://bayes.club/@pymc)
 - LinkedIn: [@pymc](https://www.linkedin.com/company/pymc/)

--- a/blog/pytensor_announcement.md
+++ b/blog/pytensor_announcement.md
@@ -45,5 +45,6 @@ We are very excited about the future of PyMC and its ecosystem.
 Connect with PyMC via:
 - PyTensor repo:  [pymc-devs/pytensor](https://github.com/pymc-devs/pytensor)
 - Join Meetup: [pymc-online-meetup](https://www.meetup.com/pymc-online-meetup/)
-- Twitter: [@pymc_devs](https://twitter.com/pymc_devs)
+- X: [@pymc_devs](https://x.com/pymc_devs)
+- Mastodon: [@pymc](https://bayes.club/@pymc) 
 - LinkedIn: [@pymc](https://www.linkedin.com/company/pymc/)

--- a/community/index.md
+++ b/community/index.md
@@ -13,7 +13,7 @@ Discourse is the best place to interact with the PyMC community and its team
 
 The PyMC community organizes [PyMCon](https://pymcon.com/), a recurring webseries which is currently ongoing! 
 
-Follow [**Discourse**](https://discourse.pymc.io/c/events/pymcon-web-series/23), [Twitter](https://twitter.com/pymc_devs), or [LinkedIn](https://www.linkedin.com/company/pymc/) to be notified about all the events!
+Follow [**Discourse**](https://discourse.pymc.io/c/events/pymcon-web-series/23), [X](https://x.com/pymc_devs), or [LinkedIn](https://www.linkedin.com/company/pymc/) to be notified about all the events!
 
 Videos from the previous PyMCon edition in 2020 are [available on YouTube](https://www.youtube.com/c/PyMCDevelopers/videos).
 
@@ -26,7 +26,7 @@ To purchase PyMC official merchandise feel free to check out the [NumFOCUS Shop]
 
 ## Social Media
 
-Twitter - You can follow us on Twitter at [@pymc_devs](https://twitter.com/pymc_devs)
+X - You can follow us on X at [@pymc_devs](https://x.com/pymc_devs)
 
 YouTube - Check out our latest videos at [@pymc-devs](https://www.youtube.com/@pymc-devs)
 

--- a/welcome.md
+++ b/welcome.md
@@ -17,7 +17,7 @@ Here is what sets it apart:
 * **User friendly**: Write your models using friendly Python syntax. [Learn Bayesian modeling](https://www.pymc.io/projects/docs/en/latest/learn.html#) from the many [example notebooks](https://www.pymc.io/projects/examples/en/latest/gallery.html).
 * **Fast**: Uses {doc}`PyTensor <pytensor:index>` as its computational backend to compile through C, Numba or JAX, [run your models on the GPU](https://www.pymc-labs.io/blog-posts/pymc-stan-benchmark/), and benefit from complex graph-optimizations.
 * **Batteries included**: Includes probability distributions, Gaussian processes, ABC, SMC and much more. It integrates nicely with {doc}`ArviZ <arviz:index>` for visualizations and diagnostics, as well as {doc}`Bambi <bambi:index>` for high-level mixed-effect models.
-* **Community focused**: Ask questions on [discourse](https://discourse.pymc.io), join [MeetUp events](https://meetup.com/pymc-online-meetup/), follow us on [Twitter](https://twitter.com/pymc_devs), and start [contributing](https://www.pymc.io/projects/docs/en/latest/contributing/index.html).
+* **Community focused**: Ask questions on [discourse](https://discourse.pymc.io), join [MeetUp events](https://meetup.com/pymc-online-meetup/), follow us on [X](https://x.com/pymc_devs), and start [contributing](https://www.pymc.io/projects/docs/en/latest/contributing/index.html).
 
 ## Example from Linear Regression
 
@@ -283,7 +283,8 @@ about/testimonials
 :caption: External links
 
 Discourse <https://discourse.pymc.io>
-Twitter <https://twitter.com/pymc_devs>
+X <https://x.com/pymc_devs>
+Mastodon <https://bayes.club/@pymc>
 YouTube <https://www.youtube.com/c/PyMCDevelopers>
 LinkedIn <https://www.linkedin.com/company/pymc/>
 Meetup <https://www.meetup.com/pymc-online-meetup/>


### PR DESCRIPTION
Replace Twitter with X and add Mastodon to social media list.

X: https://x.com/pymc_devs
Mastodon: https://bayes.club/@pymc