### PR TITLE
Fix broken PyMC Labs logo on welcome page

### DIFF
--- a/welcome.md
+++ b/welcome.md
@@ -251,7 +251,7 @@ NumFOCUS is our non-profit umbrella organization.
 :::{grid-item-card} PyMC Labs
 :link: https://pymc-labs.io
 
-<img src="https://github.com/pymc-labs/brand/blob/main/logos/4-pymc-labs-transp-black.png?raw=true"/>
+<img src="https://github.com/pymc-devs/brand/blob/main/sponsors/sponsor_logos/pymc_labs.png?raw=true"/>
 
 PyMC Labs offers professional consulting services for PyMC.
 :::


### PR DESCRIPTION
## Summary

The PyMC Labs sponsor logo on https://www.pymc.io/welcome.html is broken (404).

The current image src points to `pymc-labs/brand` (a private repo), so the asset is inaccessible to the public:
```
https://github.com/pymc-labs/brand/blob/main/logos/4-pymc-labs-transp-black.png?raw=true
```

This PR points it at the public `pymc-devs/brand/sponsors/sponsor_logos/pymc_labs.png`, matching the convention already used for the other current and past sponsors (Mistplay, ODSC, Adia Lab) on the same page.

## Test plan

- [ ] Verify the new URL resolves and renders the PyMC Labs logo
- [ ] Build the site locally / preview and confirm the Sponsors section shows the logo