### PR TITLE
Add pathmc to ecosystem page

### DIFF
--- a/about/ecosystem.md
+++ b/about/ecosystem.md
@@ -5,6 +5,7 @@
 - [Bambi](https://github.com/bambinos/bambi): BAyesian Model-Building Interface (BAMBI) in Python.
 - [calibr8](https://github.com/JuBiotech/calibr8): A toolbox for constructing detailed observation models to be used as likelihoods in PyMC.
 - [CausalPy](https://github.com/pymc-labs/CausalPy): A package focussing on causal inference in quasi-experimental settings.
+- [pathmc](https://github.com/pymc-labs/pathmc): Bayesian path analysis and structural causal modeling, with a concise DSL for estimation, identification, and interventional simulation.
 - [SunODE](https://github.com/pymc-devs/sunode): Fast ODE solver, much faster than the one that comes with PyMC.
 - [pymc-learn](https://github.com/pymc-learn/pymc-learn): Custom PyMC models built on top of pymc3_models/scikit-learn API
 


### PR DESCRIPTION
## Summary
- Adds [pathmc](https://github.com/pymc-labs/pathmc) to the General purpose section of the ecosystem page, alongside CausalPy.

## Test plan
- [ ] Verify the ecosystem page renders correctly with the new link


Made with [Cursor](https://cursor.com)